### PR TITLE
Django REST Framework 3.0 API changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Requirements
 
 * Python (2.6, 2.7 and 3.3)
 * Django 1.3+
-* Django REST Framework >= 2.2.5 (when bulk features were added to serializers)
+* Django REST Framework >= 3.0.0
 
 Installing
 ----------
@@ -44,8 +44,27 @@ The bulk views (and mixins) are very similar to Django REST Framework's own
 generic views (and mixins)::
 
     from rest_framework_bulk import ListBulkCreateUpdateDestroyAPIView
+
     class FooView(ListBulkCreateUpdateDestroyAPIView):
-        model = FooModel
+        queryset = FooModel.objects.all()
+        serializer_class = FooModelSerializer
+
+where `FooModelSerializer` is defined as::
+
+    from rest_framework_bulk.serializers import BulkListSerializer, BulkSerializerMixin
+    from rest_framework.serializers import ModelSerializer
+
+    class FooModelSerializer(BulkSerializerMixin, ModelSerializer):
+        class Meta:
+            model = FooModel
+            list_serializer_class = BulkListSerializer
+
+A `list_serializer_class` definition has become necessary due to API changes in the Django REST Framework 3.0 regarding
+multiple updates
+(see `ListSerializer in the docs <http://www.django-rest-framework.org/api-guide/serializers/#listserializer>`_ for
+details). The additional serializer mixin temporarily adds a unique field to the deserialized values for determining
+which instance to update, as read-only fields are otherwise discarded. By default the `id` field is used, but can be
+set by overriding the `update_lookup_field` class attribute.
 
 The above will allow to create the following queries
 

--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,12 @@ where `FooModelSerializer` is defined as::
             model = FooModel
             list_serializer_class = BulkListSerializer
 
-A `list_serializer_class` definition has become necessary due to API changes in the Django REST Framework 3.0 regarding
-multiple updates
+A ``list_serializer_class`` definition has become necessary due to API changes in the Django REST Framework 3.0
+regarding multiple updates
 (see `ListSerializer in the docs <http://www.django-rest-framework.org/api-guide/serializers/#listserializer>`_ for
 details). The additional serializer mixin temporarily adds a unique field to the deserialized values for determining
-which instance to update, as read-only fields are otherwise discarded. By default the `id` field is used, but can be
-set by overriding the `update_lookup_field` class attribute.
+which instance to update, as read-only fields are otherwise discarded. By default the ``id`` field is used, but can be
+set by overriding the ``update_lookup_field`` class attribute.
 
 The above will allow to create the following queries
 

--- a/rest_framework_bulk/mixins.py
+++ b/rest_framework_bulk/mixins.py
@@ -25,7 +25,7 @@ class BulkCreateModelMixin(CreateModelMixin):
             return super(BulkCreateModelMixin, self).create(request, *args, **kwargs)
 
         else:
-            serializer = self.get_serializer(data=request.DATA, many=True)
+            serializer = self.get_serializer(data=request.data, many=True)
             if serializer.is_valid():
                 self.perform_create(serializer)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -50,7 +50,7 @@ class BulkUpdateModelMixin(object):
 
         # restrict the update to the filtered queryset
         serializer = self.get_serializer(self.filter_queryset(self.get_queryset()),
-                                         data=request.DATA,
+                                         data=request.data,
                                          many=True,
                                          partial=partial)
 

--- a/rest_framework_bulk/mixins.py
+++ b/rest_framework_bulk/mixins.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, print_function
-from django.core.exceptions import ValidationError
 from rest_framework import status
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.response import Response
@@ -28,12 +27,13 @@ class BulkCreateModelMixin(CreateModelMixin):
         else:
             serializer = self.get_serializer(data=request.DATA, many=True)
             if serializer.is_valid():
-                [self.pre_save(obj) for obj in serializer.object]
-                self.object = serializer.save(force_insert=True)
-                [self.post_save(obj, created=True) for obj in self.object]
+                self.perform_create(serializer)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def perform_create(self, serializer):
+        serializer.save()
 
 
 class BulkUpdateModelMixin(object):
@@ -55,17 +55,13 @@ class BulkUpdateModelMixin(object):
                                          partial=partial)
 
         if serializer.is_valid():
-            try:
-                [self.pre_save(obj) for obj in serializer.object]
-            except ValidationError as err:
-                # full_clean on model instances may be called in pre_save
-                # so we have to handle eventual errors.
-                return Response(err.message_dict, status=status.HTTP_400_BAD_REQUEST)
-            self.object = serializer.save(force_update=True)
-            [self.post_save(obj, created=False) for obj in self.object]
+            self.perform_update(serializer)
             return Response(serializer.data, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def perform_update(self, serializer):
+        serializer.save()
 
     def partial_bulk_update(self, request, *args, **kwargs):
         kwargs['partial'] = True

--- a/rest_framework_bulk/serializers.py
+++ b/rest_framework_bulk/serializers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from rest_framework.serializers import ListSerializer
+
+
+class BulkSerializerMixin(object):
+    def to_internal_value(self, data):
+        ret = super(BulkSerializerMixin, self).to_internal_value(data)
+        if isinstance(self.root, BulkListSerializer) and self.context['view'].action in ('partial_bulk_update', 'bulk_update'):
+            id_attr = self.root.update_lookup_field
+            id_field = self.fields[id_attr]
+            id_value = id_field.get_value(data)
+            ret[id_attr] = id_value
+        return ret
+
+
+class BulkListSerializer(ListSerializer):
+    update_lookup_field = 'id'
+
+    def create(self, validated_data):
+        model_class = self.child.Meta.model
+        instances = [model_class(**item) for item in validated_data]
+        return model_class.objects.bulk_create(instances)
+
+    def update(self, instance, validated_data):
+        def _get_updated():
+            for obj in instance:
+                obj_id = getattr(obj, lookup_field)
+                update = update_dict.get(obj_id)
+                if update:
+                    for attr, value in update.items():
+                        setattr(obj, attr, value)
+                    obj.save(update_fields=update.keys())
+                    yield obj
+
+        lookup_field = self.update_lookup_field
+        update_dict = dict((item.pop(lookup_field), item) for item in validated_data)
+        return list(_get_updated())

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     package_data=get_package_data('rest_framework_bulk'),
     install_requires=[
         'django',
-        'djangorestframework',
+        'djangorestframework>=3.0.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/simple_app/serializers.py
+++ b/tests/simple_app/serializers.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from rest_framework import serializers
+from . import models
+
+
+class SimpleModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.SimpleModel

--- a/tests/simple_app/views.py
+++ b/tests/simple_app/views.py
@@ -1,6 +1,7 @@
 from rest_framework_bulk import generics
-from . import models
+from . import models, serializers
 
 
 class SimpleBulkUpdateAPIView (generics.BulkUpdateAPIView):
-    model = models.SimpleModel
+    queryset = models.SimpleModel.objects.all()
+    serializer_class = serializers.SimpleModelSerializer


### PR DESCRIPTION
This PR adapts to the breaking changes in Django REST Framework 3.0.

The DRF model serializers have been simplified a lot and therefore some functionality (e.g. `pre_save`, `post_save`) had to be dropped. `BulkListSerializer` is a similar implementation to the example of a `list_serializer_class` in the [docs](http://www.django-rest-framework.org/api-guide/serializers/#customizing-multiple-update). However, `BulkSerializerMixin` has to be used in addition, as the `id` field is usually discarded.