### PR TITLE
[enhancement/bug fix]: UUID primary key support on update

### DIFF
--- a/rest_framework_bulk/drf3/serializers.py
+++ b/rest_framework_bulk/drf3/serializers.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, unicode_literals
+import uuid
 import inspect
 
 from rest_framework.exceptions import ValidationError
@@ -61,6 +62,14 @@ class BulkListSerializer(ListSerializer):
 
         for obj in objects_to_update:
             obj_id = getattr(obj, id_attr)
+
+            # Cast UUID types to string
+            # The pk keys in validated data will be strings, while
+            # if using a UUIDField, the objects_to_update pk will be UUIDs.
+            # e.g. {'xyz': {}}.get(UUID('xyz')) == None
+            if isinstance(obj_id, uuid.UUID):
+                obj_id = str(obj_id)
+
             obj_validated_data = all_validated_data_by_id.get(obj_id)
 
             # use model serializer to actually update the model

--- a/rest_framework_bulk/tests/simple_app/models.py
+++ b/rest_framework_bulk/tests/simple_app/models.py
@@ -1,7 +1,14 @@
 from __future__ import unicode_literals, print_function
+import uuid
 from django.db import models
 
 
 class SimpleModel(models.Model):
+    number = models.IntegerField()
+    contents = models.CharField(max_length=16)
+
+
+class SimpleUUIDPKModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     number = models.IntegerField()
     contents = models.CharField(max_length=16)

--- a/rest_framework_bulk/tests/simple_app/models.py
+++ b/rest_framework_bulk/tests/simple_app/models.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, print_function
+import django
 import uuid
 from django.db import models
 
@@ -9,6 +10,11 @@ class SimpleModel(models.Model):
 
 
 class SimpleUUIDPKModel(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    if django.VERSION >= (1, 8, 0):
+        id = models.UUIDField(
+            primary_key=True,
+            default=uuid.uuid4,
+            editable=False
+        )
     number = models.IntegerField()
     contents = models.CharField(max_length=16)

--- a/rest_framework_bulk/tests/simple_app/serializers.py
+++ b/rest_framework_bulk/tests/simple_app/serializers.py
@@ -2,7 +2,7 @@ from __future__ import print_function, unicode_literals
 from rest_framework.serializers import ModelSerializer
 from rest_framework_bulk.serializers import BulkListSerializer, BulkSerializerMixin
 
-from .models import SimpleModel
+from .models import SimpleModel, SimpleUUIDPKModel
 
 
 class SimpleSerializer(BulkSerializerMixin,  # only required in DRF3
@@ -10,4 +10,10 @@ class SimpleSerializer(BulkSerializerMixin,  # only required in DRF3
     class Meta(object):
         model = SimpleModel
         # only required in DRF3
+        list_serializer_class = BulkListSerializer
+
+
+class SimpleUUIDPKSerializer(BulkSerializerMixin, ModelSerializer):
+    class Meta(object):
+        model = SimpleUUIDPKModel
         list_serializer_class = BulkListSerializer

--- a/rest_framework_bulk/tests/simple_app/views.py
+++ b/rest_framework_bulk/tests/simple_app/views.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals, print_function
 from rest_framework_bulk import generics
 
-from .models import SimpleModel
-from .serializers import SimpleSerializer
+from .models import SimpleModel, SimpleUUIDPKModel
+from .serializers import SimpleSerializer, SimpleUUIDPKSerializer
 
 
 class SimpleMixin(object):
@@ -23,3 +23,9 @@ class FilteredBulkAPIView(SimpleMixin, generics.ListBulkCreateUpdateDestroyAPIVi
 class SimpleViewSet(SimpleMixin, generics.BulkModelViewSet):
     def filter_queryset(self, queryset):
         return queryset.filter(number__gt=5)
+
+
+class SimpleUUIDAPIView(generics.ListBulkCreateUpdateDestroyAPIView):
+    model = SimpleUUIDPKModel
+    queryset = SimpleUUIDPKModel.objects.all()
+    serializer_class = SimpleUUIDPKSerializer

--- a/rest_framework_bulk/tests/test_generics.py
+++ b/rest_framework_bulk/tests/test_generics.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, print_function
 import json
+import uuid
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -115,12 +116,17 @@ class TestBulkAPIView(TestCase):
         )
 
         view = SimpleUUIDAPIView.as_view()
+        data = [
+            {'contents': 'foo', 'number': 3, 'id': obj1.pk},
+            {'contents': 'bar', 'number': 4, 'id': obj2.pk},
+        ]
+        if isinstance(obj1.pk, uuid.UUID):
+            for item in data:
+                item['id'] = str(item['id'])
+
         response = view(self.request.put(
             '',
-            json.dumps([
-                {'contents': 'foo', 'number': 3, 'id': str(obj1.pk)},
-                {'contents': 'bar', 'number': 4, 'id': str(obj2.pk)},
-            ]),
+            json.dumps(data),
             content_type='application/json',
         ))
 


### PR DESCRIPTION
Using models with a UUIDField as a primary key fails on bulk updates. This happens because, the validated_data dictionary value for the id will be a string, while the internal data type is a UUID. Therefore, this line fails to pull the values from the dictionary:

``` python
obj_validated_data = all_validated_data_by_id.get(obj_id)
```

[serializers.py line 64](https://github.com/miki725/django-rest-framework-bulk/blob/master/rest_framework_bulk/drf3/serializers.py#L64)
E.g

``` python
# if all_validated_data_by_id = {'200841c5-09cd-4a92-b60a-96f28750ecf9': {...}}
all_validated_data_by_id.get(UUID('200841c5-09cd-4a92-b60a-96f28750ecf9')) == None
```

This causes a NoneType error to be raised if obj is None here:
`updated_objects.append(self.child.update(obj, obj_validated_data))`

This PR casts the object_id to a string if it is of type UUID. Test included.
