### PR TITLE
Simplified basic usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ generic views (and mixins)::
     from rest_framework_bulk import (
         BulkListSerializer,
         BulkSerializerMixin,
-        ListBulkCreateUpdateDestroyAPIView,
+        BulkModelViewSet,
     )
 
     class FooSerializer(BulkSerializerMixin, ModelSerializer):
@@ -56,7 +56,7 @@ generic views (and mixins)::
             # only necessary in DRF3
             list_serializer_class = BulkListSerializer
 
-    class FooView(ListBulkCreateUpdateDestroyAPIView):
+    class FooView(BulkModelViewSet):
         queryset = FooModel.objects.all()
         serializer_class = FooSerializer
 


### PR DESCRIPTION
ListBulkCreateUpdateDestroyAPIView was being used in the basic example. In most cases, I think people are more likely to be using ViewSets. The BulkModelViewSet is only tangentially mentioned in the README, and the example given looks similar enough to a viewset that it is confusing. People who have a use case that requires a specific API View are probably more likely to be willing to dig, and more likely to notice that BulkModelViewSet is a viewset rather than a view.

tldr; perhaps optimize for people who are just trying to get it to work in the first place?
