### PR TITLE
fixed BulkSerializerMixin.to_internal_value

### DIFF
--- a/rest_framework_bulk/drf3/serializers.py
+++ b/rest_framework_bulk/drf3/serializers.py
@@ -26,6 +26,7 @@ class BulkSerializerMixin(object):
                 request_method in ('PUT', 'PATCH'))):
             id_field = self.fields[id_attr]
             id_value = id_field.get_value(data)
+            id_value = id_field.to_internal_value(id_value)
 
             ret[id_attr] = id_value
 


### PR DESCRIPTION
Pass the incoming value of the id field trough the field's to_internal_value method, instead of using the raw incoming value.