### PR TITLE
Add schema generator with automatic bulk action support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,3 +182,19 @@ please refer to Django REST
 `docs <http://www.django-rest-framework.org/api-guide/filtering>`_.
 Either way, please use bulk deletes with extreme caution since they
 can be dangerous.
+
+Schemas and interactive documentation
+-------------------------------------
+
+You can use BulkSchemaGenerator for your interactive docs needs::
+
+    from rest_framework.documentation import include_docs_urls
+    from rest_framework_bulk.schemas import SchemaGenerator
+
+    urlpatterns = [
+        ...
+        url(r'^docs/', include_docs_urls(title='My API title', generator_class=SchemaGenerator))
+    ]
+
+This will include bulk actions in docs for appropriate viewsets.
+Refer to DRF docs for other details on interactive documentation and schemas.

--- a/rest_framework_bulk/drf3/schemas.py
+++ b/rest_framework_bulk/drf3/schemas.py
@@ -1,0 +1,14 @@
+import rest_framework
+
+
+class BulkSchemaGenerator(rest_framework.schemas.SchemaGenerator):
+    """
+    Customized schema generator with bulk actions included
+    """
+
+    default_list_mapping = {
+        'get': 'list',
+        'put': 'bulk_update',
+        'patch': 'bulk_partial_update',
+        'delete': 'bulk_destroy',
+    }

--- a/rest_framework_bulk/schemas.py
+++ b/rest_framework_bulk/schemas.py
@@ -1,0 +1,7 @@
+from __future__ import print_function, unicode_literals
+import rest_framework
+
+
+# import schema generator only for DRF 3+
+if not str(rest_framework.__version__).startswith('2'):
+    from .drf3.schemas import *  # noqa


### PR DESCRIPTION
Based entirely on DRF's default generator with expanded
actions list. Requires yet to be released changes in DRF.
Add an example on how to use it with interactive docs.

Requires [this PR](https://github.com/encode/django-rest-framework/pull/5271) to be merged in order to work 